### PR TITLE
Skip test properly if we can't change TZ

### DIFF
--- a/t/datetime.t
+++ b/t/datetime.t
@@ -328,7 +328,7 @@ use Time::Local;
 use Time::Timezone;
 use POSIX qw(tzset);
 
-tzset;
+eval { tzset };                 # Might not be implemented everywhere
 
 my @x = localtime(785307957);
 my @y = gmtime(785307957);

--- a/t/metdate.t
+++ b/t/metdate.t
@@ -12,7 +12,8 @@ END { ok($finished, 'finished') if defined $finished }
 
 $ENV{'LANG'} = 'C';
 $ENV{'TZ'} = 'PST8PDT'; 
-tzset;
+eval { tzset; 1 }
+    or plan skip_all => "It seems POSIX::tzset is not available.";
 
 my @x = localtime(785307957);
 my @y = gmtime(785307957);

--- a/t/order1.t
+++ b/t/order1.t
@@ -11,7 +11,7 @@ END { ok($finished, 'finished') if defined $finished }
 
 $ENV{'LANG'} = 'C';
 $ENV{'TZ'} = 'PST8PDT'; 
-tzset;
+eval { tzset };                 # Might not be implemented everywhere
 
 my @x = localtime(785307957);
 my @y = gmtime(785307957);
@@ -19,10 +19,10 @@ my $hd = $y[2] - $x[2];
 $hd += 24 if $hd < 0;
 $hd %= 24;
 if ($hd != 8) {
-	import Test::More skip_all => "It seems localtime() does not honor \$ENV{TZ} when set in the test script.  Please set the TZ environment variable to PST8PDT and rerun.";
+	plan skip_all => "It seems localtime() does not honor \$ENV{TZ} when set in the test script.  Please set the TZ environment variable to PST8PDT and rerun.";
 	exit 0;
 }
-import Test::More qw(no_plan);
+plan qw(no_plan);
 
 $finished = 0;
 

--- a/t/order2.t
+++ b/t/order2.t
@@ -11,7 +11,7 @@ END { ok($finished, 'finished') if defined $finished }
 
 $ENV{'LANG'} = 'C';
 $ENV{'TZ'} = 'PST8PDT'; 
-tzset;
+eval { tzset };                 # Might not be implemented everywhere
 
 my @x = localtime(785307957);
 my @y = gmtime(785307957);
@@ -19,10 +19,10 @@ my $hd = $y[2] - $x[2];
 $hd += 24 if $hd < 0;
 $hd %= 24;
 if ($hd != 8) {
-	import Test::More skip_all => "It seems localtime() does not honor \$ENV{TZ} when set in the test script.  Please set the TZ environment variable to PST8PDT and rerun.";
+	plan skip_all => "It seems localtime() does not honor \$ENV{TZ} when set in the test script.  Please set the TZ environment variable to PST8PDT and rerun.";
 	exit 0;
 }
-import Test::More qw(no_plan);
+plan qw(no_plan);
 
 $finished = 0;
 


### PR DESCRIPTION
On Windows, with the test modules bundled with 5.14.2, it was printing the skip message but exiting 255, causing `cpan` to refuse to install it.
